### PR TITLE
Fix teleporting the correct player to the hub

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.parallel = true
 # Mod Properties
 maven_group = ru.pinkgoosik
 archives_base_name = skylands
-mod_version = 0.3.10+1.20
+mod_version = 0.3.11+1.20
 
 # Dependencies | Check these on https://fabricmc.net/develop
 minecraft_version = 1.20.1

--- a/src/main/java/skylands/command/BanCommands.java
+++ b/src/main/java/skylands/command/BanCommands.java
@@ -79,7 +79,7 @@ public class BanCommands {
 						SkylandsWorlds.getIsland(banned.getWorld()).ifPresent(isl -> {
 							if(isl.owner.uuid.equals(island.owner.uuid)) {
 								banned.sendMessage(SkylandsTexts.prefixed("message.skylands.hub_visit"));
-								Skylands.instance.hub.visit(player);
+								Skylands.instance.hub.visit(banned);
 							}
 						});
 					}


### PR DESCRIPTION
The ban command currently teleports the executing player, rather than the one who should be banned, to the hub